### PR TITLE
FEAT: create API/timeTable upload 포함

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ db.sqlite3-journal
 media
 django-react-venv/
 
-
 # If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/
 # in your Git repository. Update and uncomment the following line accordingly.
 # <django-project-name>/staticfiles/
@@ -169,3 +168,6 @@ cython_debug/
 # migrations
 migrations
 # End of https://www.toptal.com/developers/gitignore/api/django
+
+# extra
+docsfile/

--- a/project/backend/account/views.py
+++ b/project/backend/account/views.py
@@ -39,7 +39,7 @@ def createUser(request):
 
 @api_view(['GET', 'POST'])
 @permission_classes([AllowAny])
-def loginUser(request):
+def loginUser(request):                                                                                                                                                                                        
     if request.method == 'GET':
         if request.session.session_key:
             Response({"message":"you're already loggined"}, status=status.HTTP_208_ALREADY_REPORTED)

--- a/project/backend/article/serializers.py
+++ b/project/backend/article/serializers.py
@@ -1,3 +1,4 @@
+from dataclasses import fields
 from rest_framework import serializers
 from .models import Article, TimeTable, UserTimeMatchTable
 
@@ -7,14 +8,19 @@ class UserTimeMatchTableSerializer(serializers.ModelSerializer):
         model = UserTimeMatchTable
         fields = ['ptcpUser', 'Timetable']
 
-class ArticleTimeTableSerializer(serializers.ModelSerializer):
+class ArticleTimeTableSerializer_read(serializers.ModelSerializer):
     ptcpTable = serializers.StringRelatedField(many=True)
     class Meta:
         model = TimeTable
         exclude = ['article']
 
+class ArticleTimeTableSerializer_write(serializers.ModelSerializer):
+    class Meta:
+        model = TimeTable
+        fields = '__all__'
+
 class ArticleSerializer(serializers.ModelSerializer):
-    timeTable = ArticleTimeTableSerializer(many=True, read_only=True)
+    timeTable = ArticleTimeTableSerializer_read(many=True, read_only=True)
 
     def validate_date(self, data):
         """Check that startDay place before of endDay."""
@@ -29,8 +35,6 @@ class ArticleSerializer(serializers.ModelSerializer):
         else:
             print("zero")
         return data
-
-
 
     class Meta:
         model = Article


### PR DESCRIPTION
기존 Article create API에 timeTable(실험 참여 가능 시간대)를 포함하였습니다.
정상적으로 동작하는 것을 확인했고, notion API docs도 갱신했습니다.