### PR TITLE
Feat/user ptcp

### DIFF
--- a/project/backend/mypage/views.py
+++ b/project/backend/mypage/views.py
@@ -4,11 +4,12 @@ from rest_framework import viewsets, status
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
+import time
 
 from .serializers import getUserSerializer, getUserArticleSerializer,getUserPtcpSerializer, getUserPtcpTimeSerializer
-import time
 from account.models import CustomUser
 from article.models import Article, TimeTable, UserTimeMatchTable
+from article.serializers import ArticleListSerializer
 
 @api_view(['GET'])
 def getUser(request):
@@ -44,5 +45,7 @@ def getUserPtcp(request):
     # timetableData = TimeTable.objects.filter(ptcpUser=userID)
     for matchtableData in matchtableDatas:
         serializer = getUserPtcpSerializer(matchtableData)
-        res.append(serializer.data['timetable'])
+        serializer = serializer.data['timetable']
+        serializer['article'] = ArticleListSerializer(Article.objects.get(id=serializer['article'])).data
+        res.append(serializer)
     return Response(res)

--- a/project/backend/mypage/views.py
+++ b/project/backend/mypage/views.py
@@ -39,7 +39,10 @@ def getUserPtcp(request):
         return Response('로그인이 필요한 요청입니다.', status=status.HTTP_403_FORBIDDEN)
     userID = request.user
     loginUser = CustomUser.objects.get(userID=userID)
-    matchtableData = UserTimeMatchTable.objects.filter(userID=userID)
+    matchtableDatas = UserTimeMatchTable.objects.filter(userID=userID)
+    res = []
     # timetableData = TimeTable.objects.filter(ptcpUser=userID)
-    serializer = getUserPtcpSerializer(matchtableData, many=True)
-    return Response(serializer.data)
+    for matchtableData in matchtableDatas:
+        serializer = getUserPtcpSerializer(matchtableData)
+        res.append(serializer.data['timetable'])
+    return Response(res)


### PR DESCRIPTION
getUserPtcp API는 request user가 참여한 실험 article, timetable에 대한 정보를 list 형태로 전달하는 API 입니다.
list 안의 Dict 구성이 "timetable" : { 실사용 데이터 } 형태로 번잡하게 되어 있어, 더 간단하게 parsing 할 수 있도록 변경하였고, "article" key에 "article" id만 전달되던 기존에서 해당 "article" 개요가 함께 전달되도록 변경하였습니다.